### PR TITLE
fix for leftover class caused by logger script

### DIFF
--- a/lib/urlresolver/lib/log_utils.py
+++ b/lib/urlresolver/lib/log_utils.py
@@ -20,6 +20,8 @@ import xbmc
 import xbmcaddon
 from xbmc import LOGDEBUG, LOGERROR, LOGFATAL, LOGINFO, LOGNONE, LOGNOTICE, LOGSEVERE, LOGWARNING  # @UnusedImport
 
+addonsmu = xbmcaddon.Addon('script.module.urlresolver')
+
 def execute_jsonrpc(command):
     if not isinstance(command, basestring):
         command = json.dumps(command)
@@ -37,9 +39,8 @@ def _is_debugging():
 
 class Logger(object):
     __loggers = {}
-    __addon = xbmcaddon.Addon('script.module.urlresolver')
-    __name = __addon.getAddonInfo('name')
-    __addon_debug = __addon.getSetting('addon_debug') == 'true'
+    __name = addonsmu.getAddonInfo('name')
+    __addon_debug = addonsmu.getSetting('addon_debug') == 'true'
     __debug_on = _is_debugging()
     __disabled = set()
     


### PR DESCRIPTION
For some time I saw in video addons logs one warning and wanted to get rid of it: 
`the python script has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE`.
So, after a little googling, I've found out that kodi doesn't like xbmcaddon.Addon() included in object class.
The "hack" will fix N9XBMCAddon9xbmcaddon5AddonE error.