### PR TITLE
Rollback XVidStage plugin

### DIFF
--- a/lib/urlresolver/plugins/xvidstage.py
+++ b/lib/urlresolver/plugins/xvidstage.py
@@ -15,12 +15,41 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-from __generic_resolver__ import GenericResolver
+import re
+from lib import helpers, jsunpack
+from urlresolver import common
+from urlresolver.resolver import UrlResolver, ResolverError
 
-class XvidstageResolver(GenericResolver):
+
+class XvidstageResolver(UrlResolver):
     name = "xvidstage"
     domains = ["xvidstage.com", "faststream.ws"]
     pattern = '(?://|\.)((?:xvidstage\.com|faststream\.ws))/(?:embed-|)?([0-9A-Za-z]+)'
 
+    def __init__(self):
+        self.net = common.Net()
+
+    def get_media_url(self, host, media_id):
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.FF_USER_AGENT}
+        response = self.net.http_GET(web_url, headers=headers)
+        html = response.content
+        data = helpers.get_hidden(html)
+        headers['Cookie'] = response.get_headers(as_dict=True).get('Set-Cookie', '')
+        html = self.net.http_POST(web_url, headers=headers, form_data=data).content
+        
+        packed = re.findall('(eval\(function.*?)\s*</script>', html, re.DOTALL)
+        if packed:
+        
+            js = ''
+            for pack in packed:
+                js += jsunpack.unpack(pack)
+
+            sources = helpers.scrape_sources(js, patterns=['''(?P<url>[^"']+\.(?:m3u8|mp4))'''], result_blacklist='tmp')
+            
+            if sources: return helpers.pick_source(sources) + helpers.append_headers(headers)
+            
+        raise ResolverError('Unable to locate video')
+
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template="http://faststream.ws/embed-{media_id}.html")
+        return 'http://www.xvidstage.com/%s' % media_id


### PR DESCRIPTION
I recognized that after the last commit to the file which followed https://github.com/jsergio123/script.module.urlresolver/issues/18, the plugin stopped working.
We figured that the old code works after commenting out line 40.